### PR TITLE
Extract and persist OIDC claims in session

### DIFF
--- a/src/openid/callback.js
+++ b/src/openid/callback.js
@@ -7,6 +7,7 @@ import {
 } from './errors';
 
 const INDEX = '/';
+const DEFAULT_CLAIMS_PROCESSOR = (claims) => claims;
 
 /**
  * Express middleware processing OpenID callback requests using req.session.openId context.
@@ -16,6 +17,7 @@ export const callbackMiddleware = (deps) => (config) => async (req, res, next) =
   const {
     callbackParamsSupplier,
     callbackHandler,
+    claimsProcessor: claimsProcessor = DEFAULT_CLAIMS_PROCESSOR,
   } = deps;
   const {
     redirectUri,
@@ -42,7 +44,7 @@ export const callbackMiddleware = (deps) => (config) => async (req, res, next) =
 
   try {
     const tokenSet = await callbackHandler(redirectUri, params, checks);
-    const claims = tokenSet.id_token ? tokenSet.claims() : {};
+    const claims = claimsProcessor(tokenSet.id_token ? tokenSet.claims() : {});
 
     req.session.openId = {
       ...req.session.openId,

--- a/src/openid/callback.js
+++ b/src/openid/callback.js
@@ -42,9 +42,11 @@ export const callbackMiddleware = (deps) => (config) => async (req, res, next) =
 
   try {
     const tokenSet = await callbackHandler(redirectUri, params, checks);
+    const claims = tokenSet.id_token ? tokenSet.claims() : {};
 
     req.session.openId = {
       ...req.session.openId,
+      claims,
       tokenSet,
 
       // Clear authentication


### PR DESCRIPTION
Claims are extracted and saved in session as part of oauth2 callback processing when an ID token is present. If no ID token was provided, then the claims are defaulted to an empty object.

Claims can be validated and transformed prior to being saved in session via optional `claimsProcessor`.