### PR TITLE
Add `quickcaseClaimsProcessor` implementation

### DIFF
--- a/src/openid/claims-processor.js
+++ b/src/openid/claims-processor.js
@@ -1,0 +1,39 @@
+const QUICKCASE_CLAIMS = Object.freeze({
+  sub: {
+    defaultName: 'sub',
+  },
+  name: {
+    defaultName: 'name',
+  },
+  email: {
+    defaultName: 'email',
+  },
+  roles: {
+    defaultName: 'app.quickcase.claims/roles',
+    defaultValue: '',
+    prefix: true,
+    parser: (roles) => roles ? roles.split(',') : [],
+  },
+  organisations: {
+    defaultName: 'app.quickcase.claims/organisations',
+    defaultValue: '{}',
+    prefix: true,
+    parser: JSON.parse,
+  },
+});
+
+const claimProcessor = (prefix, names) => (claims) => (key, def) => {
+  const name = names[key] || def.defaultName;
+  const prefixedName = def.prefix ? prefix + name : name;
+  const rawValue = claims[prefixedName] || def.defaultValue;
+  return def.parser ? def.parser(rawValue) : rawValue;
+}
+
+export const quickcaseClaimsProcessor = (claimsConfig = {}) => (claims) => {
+  const prefix = claimsConfig.prefix || '';
+  const names = claimsConfig.names || {};
+
+  const processClaim = claimProcessor(prefix, names)(claims);
+
+  return Object.fromEntries(Object.entries(QUICKCASE_CLAIMS).map(([key, def]) => [key, processClaim(key, def)]));
+};

--- a/src/openid/claims-processor.test.js
+++ b/src/openid/claims-processor.test.js
@@ -1,0 +1,150 @@
+import {quickcaseClaimsProcessor} from './claims-processor';
+
+describe('quickcaseClaimsProcessor', () => {
+  test('should normalise and parse claims from default names when no config', () => {
+    const rawClaims = {
+      'sub': '123',
+      'name': 'John Doe',
+      'email': 'john.doe@quickcase.app',
+      'app.quickcase.claims/roles': 'role1,role2,role3',
+      'app.quickcase.claims/organisations': `{
+        "org-1": {"access": "organisation", "classification": "private"},
+        "org-2": {"access": "group", "classification": "public", "group": "group-1"}
+      }`
+    };
+
+    const claims = quickcaseClaimsProcessor()(rawClaims);
+
+    expect(claims).toEqual(expect.objectContaining({
+      'sub': '123',
+      'name': 'John Doe',
+      'email': 'john.doe@quickcase.app',
+      'roles': ['role1', 'role2', 'role3'],
+      'organisations': {
+        'org-1': {access: 'organisation', classification: 'private'},
+        'org-2': {access: 'group', classification: 'public', group: 'group-1'},
+      },
+    }));
+  });
+
+  test('should respect custom claims names', () => {
+    const rawClaims = {
+      'qc/sub': '123',
+      'qc/name': 'John Doe',
+      'qc/email': 'john.doe@quickcase.app',
+      'qc/roles': 'role1,role2,role3',
+      'qc/organisations': `{
+        "org-1": {"access": "organisation", "classification": "private"},
+        "org-2": {"access": "group", "classification": "public", "group": "group-1"}
+      }`
+    };
+
+    const claims = quickcaseClaimsProcessor({
+      names: {
+        sub: 'qc/sub',
+        name: 'qc/name',
+        email: 'qc/email',
+        roles: 'qc/roles',
+        organisations: 'qc/organisations',
+      },
+    })(rawClaims);
+
+    expect(claims).toEqual(expect.objectContaining({
+      'sub': '123',
+      'name': 'John Doe',
+      'email': 'john.doe@quickcase.app',
+      'roles': ['role1', 'role2', 'role3'],
+      'organisations': {
+        'org-1': {access: 'organisation', classification: 'private'},
+        'org-2': {access: 'group', classification: 'public', group: 'group-1'},
+      },
+    }));
+  });
+
+  test('should apply prefix to non-standard claims', () => {
+    const rawClaims = {
+      'sub': '123',
+      'name': 'John Doe',
+      'email': 'john.doe@quickcase.app',
+      'custom:app.quickcase.claims/roles': 'role1,role2,role3',
+      'custom:app.quickcase.claims/organisations': `{
+        "org-1": {"access": "organisation", "classification": "private"},
+        "org-2": {"access": "group", "classification": "public", "group": "group-1"}
+      }`
+    };
+
+    const claims = quickcaseClaimsProcessor({
+      prefix: 'custom:',
+    })(rawClaims);
+
+    expect(claims).toEqual(expect.objectContaining({
+      'sub': '123',
+      'name': 'John Doe',
+      'email': 'john.doe@quickcase.app',
+      'roles': ['role1', 'role2', 'role3'],
+      'organisations': {
+        'org-1': {access: 'organisation', classification: 'private'},
+        'org-2': {access: 'group', classification: 'public', group: 'group-1'},
+      },
+    }));
+  });
+
+  test('combine both prefix and name overrides when both provided', () => {
+    const rawClaims = {
+      'sub': '123',
+      'fullName': 'John Doe',
+      'email': 'john.doe@quickcase.app',
+      'custom:roles': 'role1,role2,role3',
+      'custom:organisations': `{
+        "org-1": {"access": "organisation", "classification": "private"},
+        "org-2": {"access": "group", "classification": "public", "group": "group-1"}
+      }`
+    };
+
+    const claims = quickcaseClaimsProcessor({
+      prefix: 'custom:',
+      names: {
+        name: 'fullName',
+        roles: 'roles',
+        organisations: 'organisations',
+      },
+    })(rawClaims);
+
+    expect(claims).toEqual(expect.objectContaining({
+      'sub': '123',
+      'name': 'John Doe',
+      'email': 'john.doe@quickcase.app',
+      'roles': ['role1', 'role2', 'role3'],
+      'organisations': {
+        'org-1': {access: 'organisation', classification: 'private'},
+        'org-2': {access: 'group', classification: 'public', group: 'group-1'},
+      },
+    }));
+  });
+
+  test('should extract roles as empty array when null', () => {
+    const rawClaims = {
+      'sub': '123',
+    };
+
+    const claims = quickcaseClaimsProcessor({})(rawClaims);
+
+    expect(claims).toEqual(expect.objectContaining({
+      'sub': '123',
+      'roles': [],
+    }));
+  });
+
+  test('should extract organisations as empty object when null', () => {
+    const rawClaims = {
+      'sub': '123',
+    };
+
+    const claims = quickcaseClaimsProcessor({})(rawClaims);
+
+    expect(claims).toEqual(expect.objectContaining({
+      'sub': '123',
+      'organisations': {},
+    }));
+  });
+});

--- a/src/openid/index.js
+++ b/src/openid/index.js
@@ -1,5 +1,6 @@
 export * from './authenticate';
 export * from './callback';
+export * from './claims-processor';
 export * from './errors';
 export * from './guard';
 export * from './logout';


### PR DESCRIPTION
Provide QuickCase-specific implementation of a claims processor in line with specs for QuickCase claims and support claims config.