### PR TITLE
[AclV2] Fix behaviour when ACL is undefined

### DIFF
--- a/src/acl-v2.js
+++ b/src/acl-v2.js
@@ -24,7 +24,7 @@ const LETTERS = Object.freeze({'C': CREATE, 'R': READ, 'U': UPDATE, 'D': DELETE}
  * @return {string | boolean} `false` if access is denied, the relevant role from the ACL if access is granted
  */
 export const check = (verb) => (userRoles) => (acl) =>
-  userRoles.find((role) => acl[role] && (acl[role] & verb) > 0) || false;
+  acl && userRoles.find((role) => acl[role] && (acl[role] & verb) > 0) || false;
 
 /**
  * Check whether the provided ACL grants at least one of the requested verbs for the given user roles.

--- a/src/acl-v2.test.js
+++ b/src/acl-v2.test.js
@@ -1,6 +1,13 @@
 import {check, checkAll, checkAny, CREATE, CRUD, DELETE, fromLegacy, READ, toBinary, UPDATE} from './acl-v2';
 
 describe('check()', () => {
+  test('should return false when acl is undefined', () => {
+    const userRoles = ['role-1'];
+    const acl = undefined;
+
+    expect(check(READ)(userRoles)(acl)).toBe(false);
+  });
+
   test('should return false when user has no roles', () => {
     const userRoles = [];
     const acl = {'role-1': CRUD};


### PR DESCRIPTION
Handle undefined ACLs by returning `false` (ie. permission denied) as ACLs are mandatory and defaults to a "deny all"