### PR TITLE
Drop support for NodeJS 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        node: [16, 18, 20, 22]
+        node: [18, 20, 22]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 Development kit to build QuickCase-flavoured ExpressJS applications.
 
 Supported NodeJS versions:
-* 16 (deprecated)
-* 18
+* 18 (deprecated)
 * 20
 * 22
 


### PR DESCRIPTION
NodeJS 18 is marked as deprecated to anticipate removal when NodeJS 24 is released