### PR TITLE
Preserve refresh token when omitted from response

### DIFF
--- a/src/openid/authenticate.js
+++ b/src/openid/authenticate.js
@@ -79,6 +79,8 @@ export const authenticateFromSession = (deps) => async (req, res) => {
         tokenSet: {
           // Preserve id_token in case it's omitted from refresh response
           id_token: tokenSet.id_token,
+          // Preserve refresh_token in case it's omitted from refresh response (non-rolling refresh)
+          refresh_token: tokenSet.refresh_token,
           // Apply refreshed tokenSet
           ...refreshedTokenSet,
         },

--- a/src/openid/authenticate.test.js
+++ b/src/openid/authenticate.test.js
@@ -173,6 +173,7 @@ describe('authenticateFromSession', () => {
       tokenSetRefresher: jest.fn().mockResolvedValue({
         access_token: 'new-access-token',
         expires_at: 9999999999999,
+        refresh_token: 'new-refresh-token',
       }),
     });
 
@@ -193,6 +194,38 @@ describe('authenticateFromSession', () => {
       access_token: 'new-access-token',
       expires_at: 9999999999999,
       id_token: 'id-123',
+      refresh_token: 'new-refresh-token',
+    });
+  });
+
+  test('should preserve refresh_token when missing from refreshed token set', async () => {
+    const authenticate = authenticateFromSession({
+      tokenSetIntrospector: jest.fn().mockResolvedValue(false),
+      tokenSetRefresher: jest.fn().mockResolvedValue({
+        access_token: 'new-access-token',
+        expires_at: 9999999999999,
+        id_token: 'new-id-token',
+      }),
+    });
+
+    const req = fromOpenIdSession({
+      tokenSet: {
+        access_token: '123',
+        id_token: 'id-123',
+        refresh_token: '456',
+        expires_at: 1,
+      },
+    });
+
+    await expect(authenticate(req)).resolves.toEqual({
+      authenticated: true,
+    });
+
+    expect(req.session.openId.tokenSet).toEqual({
+      access_token: 'new-access-token',
+      expires_at: 9999999999999,
+      id_token: 'new-id-token',
+      refresh_token: '456',
     });
   });
 


### PR DESCRIPTION
Some IdP like AWS Cognito have reusable refresh tokens which are not reissued on refresh. In this case, the existing refresh token must be preserved for reuse.