### PR TITLE
Use expired prompt config on failed refresh

### DIFF
--- a/src/openid/prompt-supplier.js
+++ b/src/openid/prompt-supplier.js
@@ -7,6 +7,7 @@ import {ERROR} from './authenticate.js';
 export const defaultPromptSupplier = (config = {}) => (auth) => {
   switch (auth.error) {
     case ERROR.EXPIRED_TOKEN:
+    case ERROR.FAILED_REFRESH:
       return config.expired ?? undefined;
     default:
       return config.default ?? undefined;

--- a/src/openid/prompt-supplier.test.js
+++ b/src/openid/prompt-supplier.test.js
@@ -39,4 +39,25 @@ describe('defaultPromptSupplier', () => {
       expect(prompt).toBe('none');
     });
   });
+
+  describe('when auth error is `failed_refresh`', () => {
+    test('should return undefined when not set', async () => {
+      const config = {
+        default: 'login consent',
+      };
+      const prompt = defaultPromptSupplier(config)({error: ERROR.FAILED_REFRESH});
+
+      expect(prompt).toBe(undefined);
+    });
+
+    test('should return expired prompt when set', async () => {
+      const config = {
+        default: 'login consent',
+        expired: 'none',
+      };
+      const prompt = defaultPromptSupplier(config)({error: ERROR.FAILED_REFRESH});
+
+      expect(prompt).toBe('none');
+    });
+  });
 });


### PR DESCRIPTION
Failed refresh is a subset of expired access token which could possibly occur when both refresh and access tokens are expired; as such it makes sense to also use the `prompt.expired` config for this scenario.