### PR TITLE
Set `id_token_hint` in authorize URL from session

### DIFF
--- a/src/openid/not-authenticated.js
+++ b/src/openid/not-authenticated.js
@@ -26,7 +26,6 @@ export const startAuth302 = (deps) => (config) => (auth = {}) => (req, res) => {
     disableNonce,
     loginHint,
     maxAge,
-    prompt,
     scope,
   } = config;
 

--- a/src/openid/not-authenticated.js
+++ b/src/openid/not-authenticated.js
@@ -34,6 +34,7 @@ export const startAuth302 = (deps) => (config) => (auth = {}) => (req, res) => {
   const state = stateGenerator();
 
   const authorizationUrl = authorizationUrlSupplier({
+    id_token_hint: req.session?.openId?.tokenSet?.id_token,
     login_hint: loginHint?.enable ? req.session.openId?.claims?.[loginHint.claim] : undefined,
     max_age: maxAge ?? undefined,
     nonce,

--- a/src/openid/not-authenticated.test.js
+++ b/src/openid/not-authenticated.test.js
@@ -136,6 +136,26 @@ describe('startAuth302', () => {
     return deps.authorizationUrlSupplier;
   }
 
+  test('should set `id_token_hint` when ID token available in existing session', async () => {
+    const ID_TOKEN = 'xxx.yyy.zzz';
+
+    const session = {
+      openId: {
+        tokenSet: {
+          id_token: ID_TOKEN
+        }
+      }
+    };
+    const authorizationUrlSupplier = await testAuthorizationUrl(options)()(session);
+
+    expect(authorizationUrlSupplier).toHaveBeenCalledWith({
+      id_token_hint: ID_TOKEN,
+      nonce: NONCE,
+      scope: options.scope,
+      state: STATE,
+    });
+  });
+
   test('should populate `login_hint` when enabled with claim', async () => {
     const config = {
       ...options,


### PR DESCRIPTION
When an ID token is present in an existing session (ie. re-authentication for a session with expired access/refresh tokens), pass the ID token to the authorisation server via the `id_token_hint` request parameter. While this may not be supported by all OIDC providers, the ones which do support it can use it to validate the user being re-authenticated is the same as the current SSO session, if one exists.

See: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest