### PR TITLE
Breaking: Rename config `loginHint.enable`

### DIFF
--- a/src/openid/not-authenticated.js
+++ b/src/openid/not-authenticated.js
@@ -34,7 +34,7 @@ export const startAuth302 = (deps) => (config) => (auth = {}) => (req, res) => {
 
   const authorizationUrl = authorizationUrlSupplier({
     id_token_hint: req.session?.openId?.tokenSet?.id_token,
-    login_hint: loginHint?.enable ? req.session.openId?.claims?.[loginHint.claim] : undefined,
+    login_hint: loginHint?.enabled ? req.session.openId?.claims?.[loginHint.claim] : undefined,
     max_age: maxAge ?? undefined,
     nonce,
     prompt: promptSupplier(auth),

--- a/src/openid/not-authenticated.test.js
+++ b/src/openid/not-authenticated.test.js
@@ -160,7 +160,7 @@ describe('startAuth302', () => {
     const config = {
       ...options,
       loginHint: {
-        enable: true,
+        enabled: true,
         claim: 'something',
       }
     };
@@ -182,7 +182,7 @@ describe('startAuth302', () => {
     const config = {
       ...options,
       loginHint: {
-        enable: true,
+        enabled: true,
         claim: 'other',
       }
     };
@@ -204,7 +204,7 @@ describe('startAuth302', () => {
     const config = {
       ...options,
       loginHint: {
-        enable: false,
+        enabled: false,
         claim: 'email',
       }
     };


### PR DESCRIPTION
For consistency with other `enabled` flags, this config property should be `enabled`