### PR TITLE
Session: Add middleware to track session expiry with cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@quickcase/javascript-sdk": "^0.4.0",
         "axios": "^1.3.3",
         "config": "^3.3.7",
+        "cookie": "^1.0.2",
         "js-yaml": "^4.1.0",
         "mustache": "^4.2.0",
         "winston": "^3.7.2"
@@ -3456,6 +3457,15 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/core-js-compat": {
@@ -10162,6 +10172,11 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="
     },
     "core-js-compat": {
       "version": "3.40.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cookie": "^1.0.2",
         "js-yaml": "^4.1.0",
         "mustache": "^4.2.0",
+        "on-headers": "^1.0.2",
         "winston": "^3.7.2"
       },
       "devDependencies": {
@@ -6514,6 +6515,15 @@
         "node": "^10.13.0 || >=12.0.0"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -12388,6 +12398,11 @@
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
       "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
       "dev": true
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.3.3",
         "config": "^3.3.7",
         "cookie": "^1.0.2",
+        "debug": "^4.4.0",
         "js-yaml": "^4.1.0",
         "mustache": "^4.2.0",
         "on-headers": "^1.0.2",
@@ -3617,12 +3618,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -6423,9 +6424,10 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/mustache": {
       "version": "4.2.0",
@@ -10295,12 +10297,11 @@
       }
     },
     "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       }
     },
     "decimal.js": {
@@ -12328,9 +12329,9 @@
       }
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "mustache": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "axios": "^1.3.3",
     "config": "^3.3.7",
     "cookie": "^1.0.2",
+    "debug": "^4.4.0",
     "js-yaml": "^4.1.0",
     "mustache": "^4.2.0",
     "on-headers": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@quickcase/javascript-sdk": "^0.4.0",
     "axios": "^1.3.3",
     "config": "^3.3.7",
+    "cookie": "^1.0.2",
     "js-yaml": "^4.1.0",
     "mustache": "^4.2.0",
     "winston": "^3.7.2"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "cookie": "^1.0.2",
     "js-yaml": "^4.1.0",
     "mustache": "^4.2.0",
+    "on-headers": "^1.0.2",
     "winston": "^3.7.2"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,5 +8,6 @@ export * as Definition from './definition/index.js';
 export * from './logging/index.js';
 export * as OpenId from './openid/index.js';
 export * as Record from './record/index.js';
+export * as Session from './session/index.js';
 export * as Template from './template/index.js';
 export * from './test/index.js';

--- a/src/session/index.js
+++ b/src/session/index.js
@@ -1,0 +1,1 @@
+export * from './track-expiry.js';

--- a/src/session/track-expiry.js
+++ b/src/session/track-expiry.js
@@ -1,0 +1,68 @@
+import * as cookie from 'cookie';
+import Debug from 'debug';
+import onHeaders from 'on-headers';
+
+const debug = Debug('express-sdk:session:track-expiry');
+
+const HEADER_SET_COOKIE = 'Set-Cookie';
+const DEFAULT_SESSION_COOKIE_NAME = 'connect.sid';
+
+/**
+ * Middleware for intercepting express-session's session cookie updates and expose the session cookie expiry as the value
+ * of a dedicated tracker cookie.
+ *
+ * This middleware must be registered BEFORE the express-session middleware to ensure it's `onHeaders` listener is
+ * triggered AFTER express-session's one and can correctly detect session cookie updates.
+ *
+ * By default, the tracker cookie is named after express-session's own cookie name suffixed with `_expiry`. A custom name
+ * can be provided using option `trackerName`.
+ *
+ * @param {Object} options
+ * @param {string?} options.sessionName - Name of express-session's cookie, defaults to `connect.sid`
+ * @param {string?} options.trackerName - Name of tracker cookie, defaults to session cookie name suffixed with `_expiry`
+ * @return ExpressJS middleware
+ */
+export const trackCookieExpiry = (options = {}) => (req, res, next) => {
+  const sessionName = options.sessionName || DEFAULT_SESSION_COOKIE_NAME;
+  const trackerName = options.trackerName || sessionName + '_expiry';
+
+  onHeaders(res, () => {
+    if (req.session?.cookie?.expires && isCookieSet(sessionName)(res)) {
+      const trackerCookie = cookie.serialize(trackerName, req.session.cookie.expires.toISOString(), {
+        ...req.session.cookie.data,
+        httpOnly: false,
+      });
+
+      debug('set-cookie %s', trackerCookie);
+
+      const prevCookie = res.getHeader(HEADER_SET_COOKIE);
+      const updatedCookie = Array.isArray(prevCookie) ? prevCookie.concat(trackerCookie) : [prevCookie, trackerCookie];
+
+      res.setHeader('Set-Cookie', updatedCookie);
+    }
+  });
+
+  return next();
+};
+
+const isCookieSet = (cookieName) => (res) => {
+  const cookies = res.getHeader(HEADER_SET_COOKIE);
+
+  if (!cookies) {
+    return false;
+  }
+
+  const predicate = (cookie) => cookie.startsWith(cookieName + '=');
+
+  if (typeof cookies === 'string') {
+    return predicate(cookies);
+  }
+
+  if (Array.isArray(cookies)) {
+    return !!cookies.find(predicate);
+  }
+
+  debug('invalid cookie format: %s', cookies);
+
+  return false;
+};

--- a/src/session/track-expiry.test.js
+++ b/src/session/track-expiry.test.js
@@ -1,0 +1,214 @@
+import {trackCookieExpiry} from './track-expiry.js';
+
+test('should not set tracker cookie when no cookie in session', () => {
+  const req = {
+    session: {
+      cookie: undefined // <-- No cookie
+    }
+  };
+  const res = {
+    getHeader: jest.fn(),
+    setHeader: jest.fn(),
+    writeHead: jest.fn(),
+  };
+  const next = jest.fn();
+
+  trackCookieExpiry()(req, res, next);
+
+  // Mock header written by express-session
+  res.getHeader.mockReturnValue('connect.sid=xxx');
+
+  res.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  expect(res.setHeader).not.toHaveBeenCalledWith('Set-Cookie', expect.anything());
+});
+
+test('should not set tracker cookie when no session cookie being written', () => {
+  const req = {
+    session: {
+      cookie: {
+        expires: new Date(),
+        data: {}
+      }
+    }
+  };
+  const res = {
+    getHeader: jest.fn(),
+    setHeader: jest.fn(),
+    writeHead: jest.fn(),
+  };
+  const next = jest.fn();
+
+  trackCookieExpiry()(req, res, next);
+
+  // No `Set-Cookie` header set by express-session
+  res.getHeader.mockReturnValue(undefined);
+
+  res.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  expect(res.setHeader).not.toHaveBeenCalledWith('Set-Cookie', expect.anything());
+});
+
+test('should not set cookie when invalid Set-Cookie header set', () => {
+  const req = {
+    session: {
+      cookie: {
+        expires: new Date(),
+        data: {}
+      }
+    }
+  };
+  const res = {
+    getHeader: jest.fn(),
+    setHeader: jest.fn(),
+    writeHead: jest.fn(),
+  };
+  const next = jest.fn();
+
+  trackCookieExpiry()(req, res, next);
+
+  // No `Set-Cookie` header set by express-session
+  res.getHeader.mockReturnValue({x: 'y'}); // <-- Not valid
+
+  res.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  expect(res.setHeader).not.toHaveBeenCalledWith('Set-Cookie', expect.anything());
+});
+
+test('should set tracker cookie when session cookie being written', () => {
+  const date = new Date('2025-04-07T12:34:56Z');
+  const req = {
+    session: {
+      cookie: {
+        expires: date,
+        data: {}
+      }
+    }
+  };
+  const res = {
+    getHeader: jest.fn(),
+    setHeader: jest.fn(),
+    writeHead: jest.fn(),
+  };
+  const next = jest.fn();
+
+  trackCookieExpiry()(req, res, next);
+
+  // Mock header written by express-session
+  res.getHeader.mockReturnValue('connect.sid=xxx');
+
+  res.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  expect(res.setHeader).toHaveBeenCalledWith('Set-Cookie', [
+    'connect.sid=xxx',
+    'connect.sid_expiry=2025-04-07T12%3A34%3A56.000Z',
+  ]);
+});
+
+test('should support arrays of cookies being written', () => {
+  const date = new Date('2025-04-07T12:34:56Z');
+  const req = {
+    session: {
+      cookie: {
+        expires: date,
+        data: {}
+      }
+    }
+  };
+  const res = {
+    getHeader: jest.fn(),
+    setHeader: jest.fn(),
+    writeHead: jest.fn(),
+  };
+  const next = jest.fn();
+
+  trackCookieExpiry()(req, res, next);
+
+  // Mock header written by express-session
+  res.getHeader.mockReturnValue([
+    'connect.sid=xxx',
+    'other.cookie=yyy',
+  ]);
+
+  res.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  expect(res.setHeader).toHaveBeenCalledWith('Set-Cookie', [
+    'connect.sid=xxx',
+    'other.cookie=yyy',
+    'connect.sid_expiry=2025-04-07T12%3A34%3A56.000Z',
+  ]);
+});
+
+test('should track session cookie with custom name', () => {
+  const date = new Date('2025-04-07T12:34:56Z');
+  const req = {
+    session: {
+      cookie: {
+        expires: date,
+        data: {}
+      }
+    }
+  };
+  const res = {
+    getHeader: jest.fn(),
+    setHeader: jest.fn(),
+    writeHead: jest.fn(),
+  };
+  const next = jest.fn();
+
+  trackCookieExpiry({sessionName: 'custom:session'})(req, res, next);
+
+  // Mock header written by express-session
+  res.getHeader.mockReturnValue('custom:session=xxx');
+
+  res.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  expect(res.setHeader).toHaveBeenCalledWith('Set-Cookie', [
+    'custom:session=xxx',
+    'custom:session_expiry=2025-04-07T12%3A34%3A56.000Z',
+  ]);
+});
+
+test('should use custom name for tracker cookie', () => {
+  const date = new Date('2025-04-07T12:34:56Z');
+  const req = {
+    session: {
+      cookie: {
+        expires: date,
+        data: {}
+      }
+    }
+  };
+  const res = {
+    getHeader: jest.fn(),
+    setHeader: jest.fn(),
+    writeHead: jest.fn(),
+  };
+  const next = jest.fn();
+
+  trackCookieExpiry({trackerName: 'custom:tracker'})(req, res, next);
+
+  // Mock header written by express-session
+  res.getHeader.mockReturnValue('connect.sid=xxx');
+
+  res.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  expect(res.setHeader).toHaveBeenCalledWith('Set-Cookie', [
+    'connect.sid=xxx',
+    'custom:tracker=2025-04-07T12%3A34%3A56.000Z',
+  ]);
+});


### PR DESCRIPTION
By exposing session expiry to browser-side javascript, this enables session timeout warnings to be implemented in the context of [WCAG 2.2 success criterion 2.2.1, ‘Timing Adjustable’](https://www.w3.org/TR/WCAG22/#timing-adjustable)