### PR TITLE
Condition OpenID RP-initiated logout

### DIFF
--- a/src/openid/logout.js
+++ b/src/openid/logout.js
@@ -3,23 +3,37 @@ import {Logger} from '../logging/index.js';
 const logger = Logger('openid:logout');
 
 /**
- * Express middleware handling destruction of session and OpenID RP-initiated logout.
+ * Express middleware handling destruction of session and optionally OpenID RP-initiated logout.
+ *
+ * By default, an RP-initiated logout will only be initiated if an ID token is present in the session. If so, this will
+ * terminate the middleware chain by returning a redirect response to the user agent. This behaviour can be forced using
+ * option `forceRpInitiatedLogout`.
+ *
+ * Otherwise, the next middleware in the chain will be called and should be used to display a logout confirmation.
  */
-export const logoutMiddleware = (deps) => (config) => async (req, res) => {
+export const logoutMiddleware = (deps) => (options = {}) => async (req, res, next) => {
   const {
     endSessionUrlSupplier,
   } = deps;
-  // const {} = config;
+  const {
+    forceRpInitiatedLogout = false
+  } = options;
 
-  const endSessionUrl = endSessionUrlSupplier({
-    id_token_hint: req.session?.openId?.tokenSet?.id_token,
-  });
+  const idToken = req.session?.openId?.tokenSet?.id_token;
 
   req.session.destroy((err) => {
     if (err) {
-      logger.warn(`Error while destroying session ${req.session.id}:`, err);
+      logger.warn(`Error while destroying session ${req.session?.id}:`, err);
     }
 
-    return res.redirect(endSessionUrl);
+    // Initiate RP-initiated logout when either forced or ID token available
+    if (endSessionUrlSupplier && (idToken || forceRpInitiatedLogout)) {
+      const endSessionUrl = endSessionUrlSupplier({
+        id_token_hint: idToken,
+      });
+      return res.redirect(endSessionUrl);
+    }
+
+    return next();
   });
 };

--- a/src/openid/logout.test.js
+++ b/src/openid/logout.test.js
@@ -1,14 +1,12 @@
 import {givenMiddleware} from '../test/index.js';
 import {logoutMiddleware} from './logout.js';
 
-const config = {};
-
 const deps = {
   endSessionUrlSupplier: ({id_token_hint}) => `http://op/session/end?id_token_hint=${id_token_hint}`,
 };
 
-test('should destroy session', async () => {
-  const middleware = logoutMiddleware(deps)(config);
+test('should destroy session and call next middleware when no ID token in session (ie. session expired)', async () => {
+  const middleware = logoutMiddleware(deps)();
 
   const req = {
     session: {
@@ -16,38 +14,34 @@ test('should destroy session', async () => {
     }
   };
 
-  await givenMiddleware(middleware).when(req).expectResponse();
+  const next = await givenMiddleware(middleware).when(req).expectNext();
 
   expect(req.session.destroy).toHaveBeenCalledTimes(1);
-});
-
-test('should redirect to end session URL', async () => {
-  const middleware = logoutMiddleware(deps)(config);
-
-  const req = {
-    session: {
-      destroy: jest.fn((cb) => cb()),
-      openId: {
-        tokenSet: {
-          id_token: 'id-token-123',
-        },
-      },
-    }
-  };
-
-  const res = await givenMiddleware(middleware).when(req).expectResponse();
-
-  expect(res.status).toEqual(302);
-  expect(res.redirect).toEqual('http://op/session/end?id_token_hint=id-token-123');
+  expect(next).toBeUndefined(); // No errors
 });
 
 test('should silently handle session destruction error', async () => {
-  const middleware = logoutMiddleware(deps)(config);
+  const middleware = logoutMiddleware(deps)();
 
   const req = {
     session: {
       id: '123',
       destroy: jest.fn((cb) => cb(new Error('Session could not be destroyed'))),
+    }
+  };
+
+  const next = await givenMiddleware(middleware).when(req).expectNext();
+
+  expect(req.session.destroy).toHaveBeenCalledTimes(1);
+  expect(next).toBeUndefined();
+});
+
+test('should destroy session and redirect to end session URL when ID token in session', async () => {
+  const middleware = logoutMiddleware(deps)();
+
+  const req = {
+    session: {
+      destroy: jest.fn((cb) => cb()),
       openId: {
         tokenSet: {
           id_token: 'id-token-123',
@@ -60,4 +54,21 @@ test('should silently handle session destruction error', async () => {
 
   expect(res.status).toEqual(302);
   expect(res.redirect).toEqual('http://op/session/end?id_token_hint=id-token-123');
+});
+
+test('should destroy session and redirect to end session URL when RP-initiated logout forced', async () => {
+  const middleware = logoutMiddleware(deps)({
+    forceRpInitiatedLogout: true,
+  });
+
+  const req = {
+    session: {
+      destroy: jest.fn((cb) => cb()),
+    }
+  };
+
+  const res = await givenMiddleware(middleware).when(req).expectResponse();
+
+  expect(res.status).toEqual(302);
+  expect(res.redirect).toEqual('http://op/session/end?id_token_hint=undefined');
 });


### PR DESCRIPTION
By default, only initiate an RP-initiated logout if the ID token is present in the session. This is because providing the logout `id_token_hint` is recommended and its absence could result in unexpected behaviour. As an alternative, when no ID token is present in the session (ie. the session likely expired and is empty), then simply destroy the session and call the next middleware in the chain.

RP-initiated logout can be forced using the `forceRpInitiatedLogout` option.