### PR TITLE
Test: Capture middleware `res.render` call

### DIFF
--- a/src/test/middleware.js
+++ b/src/test/middleware.js
@@ -28,6 +28,7 @@ const expectMiddleware = (middleware, req, expectResponse) => new Promise((resol
   res.header = res.set;
   res.json = (body) => (response.body = body, resolveResponse(response));
   res.redirect = (statusOrPath, path) => (Object.assign(response, path ? {status: statusOrPath, redirect: path} : {status: 302, redirect: statusOrPath}), resolveResponse(response));
+  res.render = (view, locals) => (Object.assign(response, {render: {view, locals}}), resolveResponse(response));
   res.send = res.json;
   res.end = () => resolveResponse(response);
 

--- a/src/test/middleware.test.js
+++ b/src/test/middleware.test.js
@@ -124,6 +124,19 @@ describe('givenMiddleware', () => {
     });
   });
 
+  test('should resolve with render', async () => {
+    const middleware = (req, res) => res.status(201).render('view.handlebars', {k1: 'v1'});
+    const res = await givenMiddleware(middleware).when({}).expectResponse();
+    expect(res).toEqual({
+      status: 201,
+      headers: {},
+      render: {
+        view: 'view.handlebars',
+        locals: {k1: 'v1'},
+      },
+    });
+  });
+
   test('should resolve with send', async () => {
     const middleware = (req, res) => res.send('some body');
     const res = await givenMiddleware(middleware).when({}).expectResponse();


### PR DESCRIPTION
For cases where a test aims to check a response was rendered without running the app and its templating engine. Note however that integration tests running app and templating engine should be preferred.