### PR TITLE
Rename `case_field_id` to `field_path` in layouts

### DIFF
--- a/src/definition/normalise-action-layout.js
+++ b/src/definition/normalise-action-layout.js
@@ -21,7 +21,7 @@ import {normaliseDisplay} from './utils/display.js';
  */
 const normaliseActionLayout = (definitionFields) => (action, layout) => {
   const actionFields = Object.fromEntries(
-    action.case_fields.map((field) => [field.case_field_id, field])
+    action.case_fields.map((field) => [field.field_path, field])
   );
 
   const steps = layout.wizard_pages
@@ -85,7 +85,7 @@ const reduceField = (transformField) => (structure, pageField) => {
 };
 
 const normaliseField = (definitionFields, actionFields) => (pageField) => {
-  const id = pageField.case_field_id;
+  const id = pageField.field_path;
   const definitionField = definitionFields[id];
   const actionField = actionFields[id];
 

--- a/src/definition/normalise-action-layout.test.js
+++ b/src/definition/normalise-action-layout.test.js
@@ -162,7 +162,7 @@ const fields = {
 const action = {
   case_fields: [
     {
-      case_field_id: 'field0',
+      field_path: 'field0',
       label: 'Label override for field 0',
       hint_text: 'Hint override for field 0',
       display_context: 'MANDATORY',
@@ -173,7 +173,7 @@ const action = {
       show_summary_change_option: true,
     },
     {
-      case_field_id: 'field1',
+      field_path: 'field1',
       label: null,
       hint_text: null,
       display_context: 'OPTIONAL',
@@ -183,7 +183,7 @@ const action = {
       show_summary_change_option: true,
     },
     {
-      case_field_id: 'field2',
+      field_path: 'field2',
       display_context: 'MANDATORY',
       show_condition: 'field1 == "No"',
       display_mode_parameters: {
@@ -191,30 +191,30 @@ const action = {
       },
     },
     {
-      case_field_id: 'field3',
+      field_path: 'field3',
       display_context: 'OPTIONAL',
       show_summary_change_option: true,
     },
     {
-      case_field_id: 'field4',
+      field_path: 'field4',
       display_context: 'OPTIONAL',
     },
     {
-      case_field_id: 'field5',
+      field_path: 'field5',
       display_context: 'OPTIONAL',
       show_summary_change_option: true,
     },
     {
-      case_field_id: 'field6',
+      field_path: 'field6',
       display_context: 'OPTIONAL',
     },
     {
-      case_field_id: 'complexNoOverrides',
+      field_path: 'complexNoOverrides',
       label: 'Populated with all members from definition',
       display_context: 'MANDATORY',
     },
     {
-      case_field_id: 'complexWithOverrides',
+      field_path: 'complexWithOverrides',
       hint_text: 'Exclusively populated with overridden members',
       display_context: 'MANDATORY',
       case_fields_complex: [
@@ -263,12 +263,12 @@ const action = {
       ],
     },
     {
-      case_field_id: 'collectionNoOverrides',
+      field_path: 'collectionNoOverrides',
       label: 'Populated with all members from definition',
       display_context: 'MANDATORY',
     },
     {
-      case_field_id: 'collectionWithOverrides',
+      field_path: 'collectionWithOverrides',
       hint_text: 'Exclusively populated with overridden members',
       display_context: 'MANDATORY',
       case_fields_complex: [
@@ -317,11 +317,11 @@ const action = {
       ],
     },
     {
-      case_field_id: 'complexWithCollectionNoOverrides',
+      field_path: 'complexWithCollectionNoOverrides',
       display_context: 'MANDATORY',
     },
     {
-      case_field_id: 'complexWithCollectionWithOverrides',
+      field_path: 'complexWithCollectionWithOverrides',
       display_context: 'MANDATORY',
       case_fields_complex: [
         {
@@ -363,11 +363,11 @@ test('should merge and normalise action fields and wizard page fields into norma
         show_condition: 'field0 STARTS_WITH_IC "Y"',
         wizard_page_fields: [
           {
-            case_field_id: 'field0',
+            field_path: 'field0',
             order: 1,
           },
           {
-            case_field_id: 'field1',
+            field_path: 'field1',
             order: 2,
           },
         ],
@@ -419,7 +419,7 @@ test('should sort steps', () => {
         order: 2,
         wizard_page_fields: [
           {
-            case_field_id: 'field2',
+            field_path: 'field2',
             order: 1,
           },
         ],
@@ -430,7 +430,7 @@ test('should sort steps', () => {
         order: 1,
         wizard_page_fields: [
           {
-            case_field_id: 'field1',
+            field_path: 'field1',
             order: 1,
           },
         ],
@@ -487,32 +487,32 @@ test('should sort fields across top-levels and columns', () => {
         order: 1,
         wizard_page_fields: [
           {
-            case_field_id: 'field6',
+            field_path: 'field6',
             order: 2,
             page_column_no: 2,
           },
           {
-            case_field_id: 'field4',
+            field_path: 'field4',
             order: 2,
             page_column_no: 1,
           },
           {
-            case_field_id: 'field2',
+            field_path: 'field2',
             order: 2,
             page_column_no: null,
           },
           {
-            case_field_id: 'field5',
+            field_path: 'field5',
             order: 1,
             page_column_no: 2,
           },
           {
-            case_field_id: 'field3',
+            field_path: 'field3',
             order: 1,
             page_column_no: 1,
           },
           {
-            case_field_id: 'field1',
+            field_path: 'field1',
             order: 1,
             page_column_no: null,
           },
@@ -647,7 +647,7 @@ describe('Complex', () => {
           order: 1,
           wizard_page_fields: [
             {
-              case_field_id: 'complexNoOverrides',
+              field_path: 'complexNoOverrides',
               order: 1,
             },
           ],
@@ -709,7 +709,7 @@ describe('Complex', () => {
           order: 1,
           wizard_page_fields: [
             {
-              case_field_id: 'complexWithOverrides',
+              field_path: 'complexWithOverrides',
               order: 1,
             },
           ],
@@ -778,7 +778,7 @@ describe('Collection of Complex', () => {
           order: 1,
           wizard_page_fields: [
             {
-              case_field_id: 'collectionNoOverrides',
+              field_path: 'collectionNoOverrides',
               order: 1,
             },
           ],
@@ -842,7 +842,7 @@ describe('Collection of Complex', () => {
           order: 1,
           wizard_page_fields: [
             {
-              case_field_id: 'collectionWithOverrides',
+              field_path: 'collectionWithOverrides',
               order: 1,
             },
           ],
@@ -913,7 +913,7 @@ describe('Collection of Complex in Complex', () => {
           order: 1,
           wizard_page_fields: [
             {
-              case_field_id: 'complexWithCollectionNoOverrides',
+              field_path: 'complexWithCollectionNoOverrides',
               order: 1,
             },
           ],
@@ -968,7 +968,7 @@ describe('Collection of Complex in Complex', () => {
           order: 1,
           wizard_page_fields: [
             {
-              case_field_id: 'complexWithCollectionWithOverrides',
+              field_path: 'complexWithCollectionWithOverrides',
               order: 1,
             },
           ],

--- a/src/definition/normalise-search-layout.js
+++ b/src/definition/normalise-search-layout.js
@@ -36,7 +36,7 @@ export const normaliseSearchInputsLayout = (type) => (layout) => {
 export const normaliseSearchResultsLayout = normaliseSearchInputsLayout;
 
 const normaliseField = (fieldExtractor) => (field) => {
-  const path = field.case_field_element_path ? `${field.case_field_id}.${field.case_field_element_path}` : field.case_field_id;
+  const path = field.case_field_element_path ? `${field.field_path}.${field.case_field_element_path}` : field.field_path;
   const id = Metadata.isMetadata(path) ? Metadata.normaliseName(path) : path
 
   const definitionField = fieldExtractor(id);

--- a/src/definition/normalise-search-layout.test.js
+++ b/src/definition/normalise-search-layout.test.js
@@ -130,7 +130,7 @@ describe('normaliseSearchInputsLayout', () => {
       case_type_id: 'type-1',
       fields: [
         {
-          case_field_id: 'fieldNotFound',
+          field_path: 'fieldNotFound',
           case_field_element_path: null,
           label: null,
           order: 1,
@@ -149,14 +149,14 @@ describe('normaliseSearchInputsLayout', () => {
       case_type_id: 'type-1',
       fields: [
         {
-          case_field_id: '[LAST_MODIFIED_DATE]',
+          field_path: '[LAST_MODIFIED_DATE]',
           case_field_element_path: null,
           label: null,
           order: 2,
           role: null
         },
         {
-          case_field_id: 'textField1',
+          field_path: 'textField1',
           case_field_element_path: null,
           label: null,
           order: 1,
@@ -194,7 +194,7 @@ describe('normaliseSearchInputsLayout', () => {
       case_type_id: 'type-1',
       fields: [
         {
-          case_field_id: 'textField1',
+          field_path: 'textField1',
           case_field_element_path: null,
           label: 'Text field 1',
           order: 1,
@@ -219,7 +219,7 @@ describe('normaliseSearchInputsLayout', () => {
       case_type_id: 'type-1',
       fields: [
         {
-          case_field_id: 'textField1',
+          field_path: 'textField1',
           case_field_element_path: null,
           label: null,
           order: 1,
@@ -243,7 +243,7 @@ describe('normaliseSearchInputsLayout', () => {
       case_type_id: 'type-1',
       fields: [
         {
-          case_field_id: 'complexField1',
+          field_path: 'complexField1',
           case_field_element_path: 'member1',
           label: null,
           order: 1,
@@ -267,7 +267,7 @@ describe('normaliseSearchInputsLayout', () => {
       case_type_id: 'type-1',
       fields: [
         {
-          case_field_id: 'complexField1',
+          field_path: 'complexField1',
           case_field_element_path: null,
           label: null,
           order: 1,
@@ -319,7 +319,7 @@ describe('normaliseSearchResultsLayout', () => {
       fields: [
         {
           metadata: true,
-          case_field_id: '[LAST_MODIFIED_DATE]',
+          field_path: '[LAST_MODIFIED_DATE]',
           case_field_element_path: null,
           label: null,
           order: 2,
@@ -327,7 +327,7 @@ describe('normaliseSearchResultsLayout', () => {
         },
         {
           metadata: false,
-          case_field_id: 'textField1',
+          field_path: 'textField1',
           case_field_element_path: null,
           label: null,
           order: 1,
@@ -356,7 +356,7 @@ describe('normaliseSearchResultsLayout', () => {
       fields: [
         {
           metadata: false,
-          case_field_id: 'textField1',
+          field_path: 'textField1',
           case_field_element_path: null,
           label: 'Text field 1',
           order: 1,
@@ -382,7 +382,7 @@ describe('normaliseSearchResultsLayout', () => {
       fields: [
         {
           metadata: false,
-          case_field_id: 'textField1',
+          field_path: 'textField1',
           case_field_element_path: null,
           label: null,
           order: 1,
@@ -407,7 +407,7 @@ describe('normaliseSearchResultsLayout', () => {
       fields: [
         {
           metadata: false,
-          case_field_id: 'complexField1',
+          field_path: 'complexField1',
           case_field_element_path: 'member1',
           label: null,
           order: 1,
@@ -432,7 +432,7 @@ describe('normaliseSearchResultsLayout', () => {
       fields: [
         {
           metadata: false,
-          case_field_id: 'complexField1',
+          field_path: 'complexField1',
           case_field_element_path: null,
           label: null,
           order: 1,

--- a/src/definition/normalise-view-layout.js
+++ b/src/definition/normalise-view-layout.js
@@ -30,9 +30,9 @@ const normaliseTab = (definitionFields) => (tab) => ({
 });
 
 const normaliseField = (definitionFields) => (tabField) => {
-  const definitionField = definitionFields[tabField.case_field.id];
+  const definitionField = definitionFields[tabField.field_path];
   return {
-    id: tabField.case_field.id,
+    id: tabField.field_path,
     label: tabField.label || undefined,
     condition: tabField.show_condition || undefined,
     ...normaliseDisplay(tabField),

--- a/src/definition/normalise-view-layout.test.js
+++ b/src/definition/normalise-view-layout.test.js
@@ -134,12 +134,7 @@ test('should normalise layout groups and fields', () => {
         show_condition: 'field1 == "Yes"',
         tab_fields: [
           {
-            case_field: {
-              id: 'field0',
-              metadata: false,
-              hidden: null,
-              security_classification: "PUBLIC",
-            },
+            field_path: 'field0',
             label: 'Overridden label',
             order: 1,
             show_condition: 'field0 == "No"',
@@ -250,21 +245,15 @@ test('should sort fields in groups', () => {
         show_condition: null,
         tab_fields: [
           {
-            case_field: {
-              id: 'field3',
-            },
+            field_path: 'field3',
             order: 3,
           },
           {
-            case_field: {
-              id: 'field1',
-            },
+            field_path: 'field1',
             order: 1,
           },
           {
-            case_field: {
-              id: 'field2',
-            },
+            field_path: 'field2',
             order: 2,
           },
         ],
@@ -301,7 +290,7 @@ test('should recursively populate complex members layout (incl. conditions) from
         show_condition: null,
         tab_fields: [
           {
-            case_field: {id: 'complexNoOverrides'},
+            field_path: 'complexNoOverrides',
           },
         ],
       },
@@ -351,7 +340,7 @@ test('should recursively populate complex members layout (incl. conditions) insi
         show_condition: null,
         tab_fields: [
           {
-            case_field: {id: 'collectionNoOverrides'},
+            field_path: 'collectionNoOverrides',
           },
         ],
       },
@@ -403,7 +392,7 @@ test('should recursively populate complex members layout (incl. conditions) in c
         show_condition: null,
         tab_fields: [
           {
-            case_field: {id: 'complexWithCollectionNoOverrides'},
+            field_path: 'complexWithCollectionNoOverrides',
           },
         ],
       },


### PR DESCRIPTION
Reflect changes from https://github.com/quickcase/definition-store/pull/596