### PR TITLE
Fix: Remove redundant isReady check for redis health

### DIFF
--- a/src/health/checks/redis-check.js
+++ b/src/health/checks/redis-check.js
@@ -15,15 +15,6 @@ export const createRedisDependencyCheck = ({
     name,
     check: async () => {
       try {
-        if (!client.isReady) {
-          return {
-            status: 'DOWN',
-            details: {
-              error: 'Client is not ready'
-            }
-          };
-        }
-
         await Promise.race([
           client.ping(),
           timeoutPromise()

--- a/src/health/checks/redis-check.test.js
+++ b/src/health/checks/redis-check.test.js
@@ -24,21 +24,6 @@ describe('createRedisDependencyCheck', () => {
     expect(mockClient.ping).toHaveBeenCalled();
   });
 
-  test('should return DOWN when isReady is false', async () => {
-    mockClient.isReady = false;
-    mockClient.isOpen = false;
-
-    const redisDependency = createRedisDependencyCheck({
-      client: mockClient
-    });
-
-    const result = await redisDependency.check();
-
-    expect(result.status).toBe('DOWN');
-    expect(result.details.error).toContain('not ready');
-    expect(mockClient.ping).not.toHaveBeenCalled();
-  });
-
   test('should return DOWN if ping fails', async () => {
     mockClient.ping.mockRejectedValue(new Error('Connection Lost'));
 


### PR DESCRIPTION
- isReady check is not applicable to cluster mode
- a ping should be sufficient for redis health check