### PR TITLE
Fix: Remove cluster mode derivation

### DIFF
--- a/src/health/checks/redis-check.js
+++ b/src/health/checks/redis-check.js
@@ -1,5 +1,6 @@
 export const createRedisDependencyCheck = ({
                                              name = 'redis',
+                                             mode,
                                              client,
                                              timeoutMs = 1000
                                            }) => {
@@ -22,11 +23,7 @@ export const createRedisDependencyCheck = ({
 
         return {
           status: 'UP',
-          details: {
-            type: client.constructor.name.includes('Cluster')
-              ? 'cluster'
-              : 'standalone'
-          }
+          ...(mode ? {details: {type: mode}} : {})
         };
       } catch (err) {
         return {

--- a/src/health/checks/redis-check.test.js
+++ b/src/health/checks/redis-check.test.js
@@ -14,13 +14,37 @@ describe('createRedisDependencyCheck', () => {
 
   test('should return UP when client isReady and ping succeeds', async () => {
     const redisDependency = createRedisDependencyCheck({
-      client: mockClient
+      client: mockClient,
+    });
+
+    const result = await redisDependency.check();
+
+    expect(result.status).toBe('UP');
+    expect(mockClient.ping).toHaveBeenCalled();
+  });
+
+  test('should return redis client type when mode is provided', async () => {
+    const redisDependency = createRedisDependencyCheck({
+      client: mockClient,
+      mode: 'standalone',
     });
 
     const result = await redisDependency.check();
 
     expect(result.status).toBe('UP');
     expect(result.details.type).toBe('standalone');
+    expect(mockClient.ping).toHaveBeenCalled();
+  });
+
+  test('should not have redis client type when mode is not provided', async () => {
+    const redisDependency = createRedisDependencyCheck({
+      client: mockClient,
+    });
+
+    const result = await redisDependency.check();
+
+    expect(result.status).toBe('UP');
+    expect(result.details?.type).toBeUndefined();
     expect(mockClient.ping).toHaveBeenCalled();
   });
 
@@ -40,7 +64,8 @@ describe('createRedisDependencyCheck', () => {
     mockClient.constructor.name = 'RedisCluster';
 
     const redisDependency = createRedisDependencyCheck({
-      client: mockClient
+      client: mockClient,
+      mode: 'cluster',
     });
 
     const result = await redisDependency.check();


### PR DESCRIPTION
- Derivation of cluster mode is not reliable
- Add parameter to pass mode for redis client. If provided, show in the details